### PR TITLE
Clean waitlist page and fix email deploy error

### DIFF
--- a/src/components/layout/landpage-waitlist/layout/EmailCapture.tsx
+++ b/src/components/layout/landpage-waitlist/layout/EmailCapture.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import SignupCounter from '@/components/layout/landpage-waitlist/SignupCounter';
+// Counter removed for waitlist
 import { useUTM } from "@/hooks/useUTM";
 import { analytics } from "@/services/analytics";
 import { addToWaitlist } from "@/services/waitlistService";
@@ -273,10 +273,7 @@ const EmailCapture = () => {
                 </p>
               </form>
 
-              {/* Social proof */}
-              <div className="mt-8 text-center">
-                <SignupCounter />
-              </div>
+              {/* Social proof removed */}
             </div>
           </div>
         </div>

--- a/src/components/layout/landpage-waitlist/layout/FinalCTA.tsx
+++ b/src/components/layout/landpage-waitlist/layout/FinalCTA.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import SignupCounter from '@/components/layout/landpage-waitlist/SignupCounter';
+// Counter removed for waitlist
 import { useUTM } from "@/hooks/useUTM";
 import { analytics } from "@/services/analytics";
 import { addToWaitlist } from "@/services/waitlistService";
@@ -77,9 +77,7 @@ const FinalCTA = () => {
                     </>
                   )}
                 </div>
-                <div className="flex justify-center sm:justify-end">
-                  <SignupCounter />
-                </div>
+                {/* Counter removed */}
               </div>
             </div>
           </div>

--- a/src/components/layout/landpage-waitlist/layout/Hero.tsx
+++ b/src/components/layout/landpage-waitlist/layout/Hero.tsx
@@ -1,6 +1,5 @@
 import { useState, useRef } from "react";
-import SignupCounter from '@/components/layout/landpage-waitlist/SignupCounter';
-import TestimonialsGrid from '@/components/layout/landpage-waitlist/TestimonialsGrid';
+// Counters and testimonials removed for waitlist
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -157,9 +156,7 @@ const Hero = () => {
                           </>
                         )}
                       </div>
-                      <div className="flex justify-center sm:justify-end">
-                        <SignupCounter />
-                      </div>
+                      {/* Counter removed */}
                     </div>
                   </motion.div>
                 )}
@@ -173,11 +170,7 @@ const Hero = () => {
                 <span>Acesso antecipado à convites por e-mail</span>
               </div>
             </motion.div>
-            <div className="mt-8 lg:mt-12">
-              <div className="max-w-3xl mx-auto lg:mx-0">
-                <TestimonialsGrid />
-              </div>
-            </div>
+            {/* Testimonials removed */}
           </motion.div>
 
           <motion.div initial={{ opacity: 0, x: 50 }} animate={{ opacity: 1, x: 0 }} transition={{ duration: 0.8, delay: 0.4 }} className="relative flex justify-center">

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,11 +2,12 @@
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "./types";
 
-// Load Supabase config from environment variables. For Vite, set VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY.
-const SUPABASE_URL =
-  import.meta.env.VITE_SUPABASE_URL || "";
+// Load Supabase config from environment variables. Prefer PUBLISHABLE, fallback to ANON for compatibility with different env setups.
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || "";
 const SUPABASE_PUBLISHABLE_KEY =
-  import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY || "";
+  import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY ||
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  "";
 
 if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
   // Warn in development — the build should inject these via Vite.
@@ -14,7 +15,7 @@ if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
   // If keys were previously committed, rotate them in your Supabase project immediately.
   // eslint-disable-next-line no-console
   console.warn(
-    "Supabase config missing: set VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY in your environment."
+    "Supabase config missing: set VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY (or VITE_SUPABASE_ANON_KEY) in your environment."
   );
 }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,12 +1,15 @@
 import { createClient } from '@supabase/supabase-js'
 
-// Usar variáveis de ambiente
+// Usar variáveis de ambiente (com fallback entre ANON e PUBLISHABLE)
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || ''
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || ''
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY ||
+  ''
 
 // Validar se as variáveis estão definidas
 if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Variáveis de ambiente do Supabase não configuradas corretamente')
+  throw new Error('Variáveis de ambiente do Supabase ausentes: defina VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY (ou VITE_SUPABASE_PUBLISHABLE_KEY)')
 }
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {

--- a/src/pages/LandingWaitlist.tsx
+++ b/src/pages/LandingWaitlist.tsx
@@ -22,13 +22,10 @@ const LandingWaitlist = () => {
       <Problems />
       <HowItWorks />
       <TechSection />
-      <Stats />
       <Features />
-      <SocialProof />
       <AdvancedFeatures />
       <PricingAndFeedback />
       <EmailCapture />
-      <InteractiveStats />
       <WordCloudSuggestions />
       <FinalCTA />
       <NewFooter />

--- a/src/services/waitlistService.ts
+++ b/src/services/waitlistService.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { supabase } from "@/lib/supabase";
+import { supabase } from "@/integrations/supabase/client";
 import { emailQueueService } from './emailQueueService';
 // UTM type removed because it's not referenced directly in this module
 


### PR DESCRIPTION
Remove testimonials and numeric counters from the waitlist page and fix Supabase environment variable handling for production deployments.

The email submission error on Hostinger was due to inconsistent Supabase environment variable naming (e.g., `VITE_SUPABASE_ANON_KEY` vs `VITE_SUPABASE_PUBLISHABLE_KEY`) and disparate Supabase client imports. This PR unifies client usage and adds fallbacks to ensure the application correctly initializes Supabase in various production environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5ba9044-33e5-4ac4-85c5-dd92f0c8aaff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5ba9044-33e5-4ac4-85c5-dd92f0c8aaff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

