### PR TITLE
Fix AI provider selection without API key

### DIFF
--- a/src/services/aiContingencyService.ts
+++ b/src/services/aiContingencyService.ts
@@ -519,7 +519,7 @@ class AIContingencyService {
     // Se contingência não está habilitada, usar apenas o provedor preferido
     if (!this.settings?.contingencyEnabled) {
       const provider = this.providers.find(
-        (p) => p.key === preferredProvider && p.active && p.apiKey
+        (p) => p.key === preferredProvider && p.active
       );
       if (!provider) {
         throw new Error("Provedor especificado não está disponível");


### PR DESCRIPTION
## Summary
- avoid rejecting active AI provider if API key is missing

## Testing
- `npm test` *(fails: TypeError: supabase.from(...).select(...).eq(...).order is not a function, Mic is not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c0448eee9c83278a030b569da0240b