### PR TITLE
feat: add UGC video action

### DIFF
--- a/src/components/CopyResultActions.tsx
+++ b/src/components/CopyResultActions.tsx
@@ -4,12 +4,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Copy, RefreshCw, Save, Share2, Calendar, Instagram, Facebook, Linkedin, Mail, MessageCircle, Download, Eye, Sparkles, Zap, Heart, TrendingUp } from "lucide-react";
+import { Copy, RefreshCw, Save, Share2, Calendar, Instagram, Facebook, Linkedin, Mail, MessageCircle, Download, Eye, Sparkles, Zap, Heart, TrendingUp, Video } from "lucide-react";
 
 interface CopyResultActionsProps {
   generatedCopy: string;
   onRegenerate?: () => void;
   onSave?: () => void;
+  onGenerateUGC?: () => void;
   canRegenerate?: boolean;
   isRegenerating?: boolean;
 }
@@ -18,6 +19,7 @@ export const CopyResultActions = ({
   generatedCopy,
   onRegenerate,
   onSave,
+  onGenerateUGC,
   canRegenerate = true,
   isRegenerating = false
 }: CopyResultActionsProps) => {
@@ -80,6 +82,10 @@ export const CopyResultActions = ({
   const saveToLibrary = () => {
     onSave?.();
     toast({ title: "Copy salva!", description: "Adicionada à sua biblioteca pessoal." });
+  };
+
+  const generateUGCVideo = () => {
+    onGenerateUGC?.();
   };
 
   return (
@@ -198,6 +204,10 @@ export const CopyResultActions = ({
             <Button type="button" variant="outline" size="sm" onClick={saveToLibrary} className="justify-start h-10 sm:h-12">
               <Save className="h-3 w-3 sm:h-4 sm:w-4 mr-2" />
               <span className="text-sm">Salvar</span>
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={generateUGCVideo} className="justify-start h-10 sm:h-12">
+              <Video className="h-3 w-3 sm:h-4 sm:w-4 mr-2" />
+              <span className="text-sm">Gerar UGC Vídeo</span>
             </Button>
           </div>
         </div>

--- a/src/components/FreeModeComposer.tsx
+++ b/src/components/FreeModeComposer.tsx
@@ -295,6 +295,7 @@ ${processedPrompt}
                 generatedCopy={generatedCopy}
                 onRegenerate={() => handleGenerate()}
                 onSave={() => { notifications.success.copied(); }}
+                onGenerateUGC={() => notifications.info.featureComingSoon('Geração de UGC Vídeo')}
                 canRegenerate={credits >= 2}
                 isRegenerating={isGenerating}
               />

--- a/src/components/SimplifiedFreeModeComposer.tsx
+++ b/src/components/SimplifiedFreeModeComposer.tsx
@@ -401,6 +401,7 @@ export const SimplifiedFreeModeComposer = ({ credits, onCreditsUpdate, onStatsUp
               generatedCopy={generatedCopy}
               onRegenerate={regenerate}
               onSave={() => { toast({ title: "Copy salva!", description: "Adicionada à sua biblioteca pessoal." }); }}
+              onGenerateUGC={() => notifications.info.featureComingSoon('Geração de UGC Vídeo')}
               canRegenerate={credits >= 1}
               isRegenerating={isGenerating}
             />


### PR DESCRIPTION
## Summary
- add optional `onGenerateUGC` prop to `CopyResultActions`
- wire up new "Gerar UGC Vídeo" advanced action button
- pass placeholder `onGenerateUGC` handlers in composers

## Testing
- `npm test` *(fails: supabase.from(...).select(...).eq is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a75ede208327905c25086f1fcd79